### PR TITLE
[Password reset] The “Email” input field is overlapped by description text #234

### DIFF
--- a/src/containers/guest-home-page/forgot-password/ForgotPassword.styles.js
+++ b/src/containers/guest-home-page/forgot-password/ForgotPassword.styles.js
@@ -25,7 +25,8 @@ export const styles = {
       mb: '16px'
     },
     description: {
-      typography: 'body2'
+      typography: 'body2',
+      mb: '20px'
     }
   }
 }


### PR DESCRIPTION
### Work done
The “Email” input field is displayed aligned on the password reset pop-up.
### Issue
https://github.com/Space2Study-UA-4427-4288-02-01/Issues/issues/234
### Before
<img width="539" height="464" alt="Screenshot 2025-09-27 171821" src="https://github.com/user-attachments/assets/191a2877-2009-48aa-9fce-4d03fad37bdb" />

### Afrer
<img width="540" height="480" alt="Screenshot 2025-09-27 171856" src="https://github.com/user-attachments/assets/ad6737c8-b543-44b9-bc7d-56ed58036bc1" />
