### PR TITLE
[39] Implement email confirmation functionality

### DIFF
--- a/src/pages/confirm-email/ConfirmEmail.tsx
+++ b/src/pages/confirm-email/ConfirmEmail.tsx
@@ -1,0 +1,36 @@
+import { useCallback } from 'react'
+import { useNavigate } from 'react-router'
+import { AuthService } from '~/services/auth-service'
+import useAxios from '~/hooks/use-axios'
+import Loader from '~/components/loader/Loader'
+import { defaultResponses } from '~/constants'
+
+const ConfirmEmail = () => {
+  const params = new URLSearchParams(window.location.search)
+  const confirmToken = params.get('confirmToken') ?? ''
+  const navigate = useNavigate()
+
+  const confirmEmail = useCallback(
+    () => AuthService.confirmEmail(confirmToken),
+    [confirmToken]
+  )
+
+  const { loading, response } = useAxios({
+    service: confirmEmail,
+    fetchOnMount: true,
+    defaultResponse: defaultResponses.array
+  })
+
+  if (loading) {
+    return <Loader pageLoad size={70} />
+  }
+
+  // TODO: Add success/error popup with redirect to login page
+  if (response) {
+    navigate('/')
+  }
+
+  return <div></div>
+}
+
+export default ConfirmEmail

--- a/src/plugins/axiosClient.ts
+++ b/src/plugins/axiosClient.ts
@@ -4,6 +4,9 @@ import qs from 'qs'
 export const axiosClient: AxiosInstance = axios.create({
   withCredentials: true,
   baseURL: import.meta.env.VITE_API_BASE_PATH,
+  headers: {
+    'Content-Type': 'application/json'
+  },
   paramsSerializer: (params) => {
     return encodeURI(qs.stringify(params, { arrayFormat: 'repeat' }))
   }

--- a/src/router/constants/guestRoutes.ts
+++ b/src/router/constants/guestRoutes.ts
@@ -1,5 +1,6 @@
 export const guestRoutes = {
   home: { route: '/', path: '/' },
+  confirmEmail: { route: 'confirm-email', path: '/confirm-email' },
   welcome: { route: 'welcome', path: '/#welcome' },
   student: { route: 'student', path: 'student' },
   tutor: { route: 'tutor', path: 'tutor' },

--- a/src/router/routes/guestRouter.tsx
+++ b/src/router/routes/guestRouter.tsx
@@ -5,13 +5,18 @@ import { guestRoutes } from '~/router/constants/guestRoutes'
 import { privacyPolicy } from '~/router/constants/crumbs'
 
 const CookiePolicy = lazy(() => import('~/pages/cookie-policy/CookiePolicy'))
+const ConfirmEmail = lazy(() => import('~/pages/confirm-email/ConfirmEmail'))
 
 export const guestRouter = (
-  <Route
-    element={<CookiePolicy />}
-    handle={{
-      crumb: privacyPolicy
-    }}
-    path={guestRoutes.privacyPolicy.route}
-  />
+  <>
+    <Route
+      element={<CookiePolicy />}
+      handle={{
+        crumb: privacyPolicy
+      }}
+      path={guestRoutes.privacyPolicy.route}
+    />
+
+    <Route element={<ConfirmEmail />} path={guestRoutes.confirmEmail.route} />
+  </>
 )

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -8,6 +8,7 @@ import { createUrlPath } from '~/utils/helper-functions'
 import { URLs } from '~/constants/request'
 import {
   ApiMethodEnum,
+  ConfirmResponse,
   GoogleAuthParams,
   LoginParams,
   LoginResponse,
@@ -21,9 +22,10 @@ export const AuthService = {
   refresh: (): Promise<AxiosResponse<LoginResponse>> => {
     return axiosClient.get(URLs.auth.refresh)
   },
-  confirmEmail: (confirmToken: string): Promise<AxiosResponse> => {
-    const confirmUrl = createUrlPath(URLs.auth.confirm, confirmToken)
-    return axiosClient.get(confirmUrl)
+  confirmEmail: (
+    confirmToken: string
+  ): Promise<AxiosResponse<ConfirmResponse>> => {
+    return axiosClient.post(URLs.auth.confirm, { confirmToken })
   },
   forgotPassword: (userEmail: string): Promise<AxiosResponse> => {
     return axiosClient.post(URLs.auth.forgotPassword, userEmail)

--- a/src/types/user/user-interfaces/user.interfaces.ts
+++ b/src/types/user/user-interfaces/user.interfaces.ts
@@ -88,3 +88,6 @@ export interface AccessToken {
   role: UserRole
   isFirstLogin: boolean
 }
+export interface ConfirmResponse {
+  message: string
+}


### PR DESCRIPTION
This is the FE part of [[Email Confirmation] Implement email confirmation functionality](https://github.com/Space2Study-UA-4427-4288-02-01/Issues/issues/39)

- Integrate /auth/confirm-email endpoint
- Register new route
- Update accessToken payload (added user's `firstName` and `lastName`)