### PR TITLE
[233] Bugfix - description is matching to mockup

### DIFF
--- a/src/constants/translations/en/signup.json
+++ b/src/constants/translations/en/signup.json
@@ -7,7 +7,7 @@
   "and": "and",
   "googleButton": "Sign up with Google",
   "continue": "or continue",
-  "haveAccount": "Already have a tutor account?",
+  "haveAccount": "Already have a Space2Study account?",
   "joinUs": "Login!",
   "confirmEmailTitle": "Your email address needs to be verified",
   "confirmEmailMessage": "We sent a confirmation email to: ",


### PR DESCRIPTION
### Work done
The text under "Sign Up with Google" button is "Already have a Space2Study account? Log In!" and is matching to mockup.

### Issue 
https://github.com/Space2Study-UA-4427-4288-02-01/Issues/issues/233